### PR TITLE
Revert back to AmazonLinux 2

### DIFF
--- a/example/instance.tf
+++ b/example/instance.tf
@@ -1,6 +1,6 @@
 # an example instance in the private subnet
 resource "aws_instance" "private_instance" {
-  ami                    = data.aws_ami.amazon_linux_2023.id
+  ami                    = data.aws_ami.amazon_linux_2.id
   instance_type          = "t3.micro"
   iam_instance_profile   = aws_iam_instance_profile.private_instance.name
   subnet_id              = module.vpc.private_subnets[0]
@@ -35,8 +35,8 @@ resource "aws_security_group" "private_instance" {
   }
 }
 
-# AMI of the latest Amazon Linux 2023 (non-minimal)
-data "aws_ami" "amazon_linux_2023" {
+# AMI of the latest Amazon Linux 2 
+data "aws_ami" "amazon_linux_2" {
   most_recent = true
   owners      = ["amazon"]
   filter {
@@ -49,7 +49,7 @@ data "aws_ami" "amazon_linux_2023" {
   }
   filter {
     name   = "name"
-    values = ["al2023-ami-2*"]
+    values = ["amzn2-ami-hvm-*"]
   }
   filter {
     name   = "virtualization-type"

--- a/main.tf
+++ b/main.tf
@@ -67,11 +67,15 @@ data "aws_ami" "this" {
   }
   filter {
     name   = "name"
-    values = ["al2023-ami-2*"]
+    values = ["amzn2-ami-hvm-*"]
   }
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
+  }
+  filter {
+    name   = "block-device-mapping.volume-type"
+    values = ["gp2"]
   }
 }
 

--- a/snat.sh
+++ b/snat.sh
@@ -53,9 +53,9 @@ while [ $EXTWORKING -eq 0 ]; do
       echo "Failed removing default gw through $CGW"
     fi
     # Modify the generated systemd eni config to disable gateway as a safeguard
-    sed --in-place -e 's/RouteMetric=512/RouteMetric=1522/g' \
-      -e 's/UseGateway=true/UseGateway=false/g' \
-      "/run/systemd/network/70-$CGW.network.d/eni.conf"
+    # sed --in-place -e 's/RouteMetric=512/RouteMetric=1522/g' \
+    #   -e 's/UseGateway=true/UseGateway=false/g' \
+    #   "/run/systemd/network/70-$CGW.network.d/eni.conf"
   done
   # Check for internet is working
   if curl --retry 2 https://google.com; then


### PR DESCRIPTION
AL2023 has a nasty bug where you cannot remove the default gateway for the original interface without it coming back later - killing the nat instance.